### PR TITLE
fix: Network.Pcap.statistics to throw on non-live Pcap handles

### DIFF
--- a/Network/Pcap/Base.hsc
+++ b/Network/Pcap/Base.hsc
@@ -689,7 +689,7 @@ statistics hdl =
                         }
 
 foreign import ccall unsafe pcap_stats
-    :: Ptr PcapTag -> Ptr Statistics -> IO Int
+    :: Ptr PcapTag -> Ptr Statistics -> IO CInt
 
 -- | Version of the library.  The returned pair consists of the major
 -- and minor version numbers.


### PR DESCRIPTION
Avoid making Haskell treat C int as long (Haskell's Int). Without this patch:

```
Prelude Network.Pcap> openOffline "test/empty.pcap" >>= statistics 
Statistics {statReceived = 129485792, statDropped = 1, statIfaceDropped = 129485816}
Prelude Network.Pcap> openOffline "test/empty.pcap" >>= statistics 
Statistics {statReceived = 129683784, statDropped = 1, statIfaceDropped = 115781272}
Prelude Network.Pcap> 
```

(returns different garbage every time it is called).

With this patch:
`> cabal repl --ghc-options="-lpcap"`

```
Prelude Network.Pcap> openOffline "test/empty.pcap" >>= statistics
*** Exception: user error (Statistics aren't available from savefiles)
Prelude Network.Pcap> 
```

Bryan, thank you for maintaining this package!
