### PR TITLE
Add DLT_DBUS

### DIFF
--- a/Network/Pcap/Base.hsc
+++ b/Network/Pcap/Base.hsc
@@ -963,6 +963,9 @@ data Link
 #ifdef DLT_PFSYNC
     | DLT_PFSYNC
 #endif
+#ifdef DLT_DBUS
+    | DLT_DBUS                          -- ^ Raw D-Bus messages
+#endif
     deriving (Eq, Ord, Read, Show)
 
 packLink :: Link -> CInt
@@ -1207,6 +1210,9 @@ packLink l = case l of
 #ifdef DLT_IEEE802_15_4
     DLT_IEEE802_15_4 -> #const DLT_IEEE802_15_4
 #endif
+#ifdef DLT_DBUS
+    DLT_DBUS -> #const DLT_DBUS
+#endif
     DLT_UNKNOWN _ -> error "cannot pack unknown link type"
 
 unpackLink :: CInt -> Link
@@ -1450,5 +1456,8 @@ unpackLink l = case l of
 #endif
 #ifdef DLT_IEEE802_15_4
     (#const DLT_IEEE802_15_4) -> DLT_IEEE802_15_4
+#endif
+#ifdef DLT_DBUS
+    (#const DLT_DBUS)-> DLT_DBUS
 #endif
     unk -> DLT_UNKNOWN (fromIntegral unk)

--- a/Network/Pcap/Base.hsc
+++ b/Network/Pcap/Base.hsc
@@ -1207,9 +1207,7 @@ packLink l = case l of
 #ifdef DLT_IEEE802_15_4
     DLT_IEEE802_15_4 -> #const DLT_IEEE802_15_4
 #endif
-#ifdef DLT_IEEE802_15_4
     DLT_UNKNOWN _ -> error "cannot pack unknown link type"
-#endif
 
 unpackLink :: CInt -> Link
 unpackLink l = case l of
@@ -1453,6 +1451,4 @@ unpackLink l = case l of
 #ifdef DLT_IEEE802_15_4
     (#const DLT_IEEE802_15_4) -> DLT_IEEE802_15_4
 #endif
-#ifdef DLT_IEEE802_15_4
     unk -> DLT_UNKNOWN (fromIntegral unk)
-#endif


### PR DESCRIPTION
I've just been nudged to make [Bustle](https://wiki.freedesktop.org/www/Software/Bustle/) use `DLT_DBUS` in the pcap logs it captures now. That bit is written in C, so [no problem](https://github.com/wjt/bustle/commit/4168158511abbdb450cc86b5eb6e09bedd98cfcf), but I'd ideally like the viewer to check the header when it loads files.

There are 100 other `DLT_*` flags defined on my system which are not covered by this binding: I can only apologise for not having the time to add them all.
